### PR TITLE
Rename `{Provider}PaymentGateway` to `{Provider}PaymentRequest`.

### DIFF
--- a/src/Console/Commands/AddProvider.php
+++ b/src/Console/Commands/AddProvider.php
@@ -77,8 +77,8 @@ class AddProvider extends Command
         $provider = Str::studly($this->id);
 
         $this->putFile(
-            app_path("Services/Payment/{$provider}PaymentGateway.php"),
-            $this->makeFile(__DIR__ . '/../stubs/payment-gateway.stub', ['name' => $provider])
+            app_path("Services/Payment/{$provider}PaymentRequest.php"),
+            $this->makeFile(__DIR__ . '/../stubs/payment-request.stub', ['name' => $provider])
         );
 
         $this->putFile(

--- a/src/Console/stubs/payment-request.stub
+++ b/src/Console/stubs/payment-request.stub
@@ -8,7 +8,7 @@ use Payavel\Models\PaymentTransaction;
 use Payavel\Models\Wallet;
 use Payavel\PaymentRequest;
 
-class {{ name }}PaymentGateway extends PaymentRequest
+class {{ name }}PaymentRequest extends PaymentRequest
 {
     /**
      * Set up the request.

--- a/src/PaymentService.php
+++ b/src/PaymentService.php
@@ -196,7 +196,7 @@ class PaymentService
         }
 
         $gateway = config('payment.test_mode', false)
-            ? config('payment.test.gateway', '\\App\\Services\\Payment\\FakePaymentGateway')
+            ? config('payment.test.gateway', '\\App\\Services\\Payment\\FakePaymentRequest')
             : $this->driver->resolveGatewayClass($provider);
 
         if (! class_exists($gateway)) {

--- a/src/database/factories/PaymentProviderFactory.php
+++ b/src/database/factories/PaymentProviderFactory.php
@@ -32,7 +32,7 @@ class PaymentProviderFactory extends Factory
         return [
             'id' => $id,
             'name' => $provider,
-            'request_class' => "\App\Services\Payment\{$studlyProvider}PaymentGateway",
+            'request_class' => "\App\Services\Payment\{$studlyProvider}PaymentRequest",
             'request_class' => "\App\Services\Payment\{$studlyProvider}PaymentResponse",
         ];
     }

--- a/src/stubs/config/provider.stub
+++ b/src/stubs/config/provider.stub
@@ -1,6 +1,6 @@
 
         '{{ id }}' => [
             'name' => '{{ name }}',
-            'request_class' => \App\Services\Payment\{{ provider }}PaymentGateway::class,
+            'request_class' => \App\Services\Payment\{{ provider }}PaymentRequest::class,
             'response_class' => \App\Services\Payment\{{ provider }}PaymentResponse::class,
         ],

--- a/tests/Feature/AddProviderCommandTest.php
+++ b/tests/Feature/AddProviderCommandTest.php
@@ -56,7 +56,7 @@ class AddProviderCommandTest extends TestCase
 
         $servicePath = app_path('Services/Payment');
 
-        $this->assertTrue(file_exists("{$servicePath}/{$provider}PaymentGateway.php"));
+        $this->assertTrue(file_exists("{$servicePath}/{$provider}PaymentRequest.php"));
         $this->assertTrue(file_exists("{$servicePath}/{$provider}PaymentResponse.php"));
     }
 }

--- a/tests/GatewayTestCase.php
+++ b/tests/GatewayTestCase.php
@@ -60,7 +60,7 @@ abstract class GatewayTestCase extends TestCase
             'payment.providers' => [
                 $this->provider => [
                     'name' => Str::headline($this->provider),
-                    'request_class' => FakePaymentGateway::class,
+                    'request_class' => FakePaymentRequest::class,
                     'response_class' => FakePaymentResponse::class,
                 ],
             ],
@@ -82,7 +82,7 @@ abstract class GatewayTestCase extends TestCase
         $provider = PaymentProvider::create([
             'id' => 'test',
             'name' => 'Test',
-            'request_class' => FakePaymentGateway::class,
+            'request_class' => FakePaymentRequest::class,
             'response_class' => FakePaymentResponse::class,
         ]);
 
@@ -95,7 +95,7 @@ abstract class GatewayTestCase extends TestCase
     }
 }
 
-class FakePaymentGateway extends PaymentRequest
+class FakePaymentRequest extends PaymentRequest
 {
     public function getWallet(Wallet $wallet)
     {


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Renames the `{Provider}PaymentGateway` to `{Provider}PaymentRequest` to better describe the responsabilities of the class.

### **Does this relate to any issue?** :link:
Closes #14 
